### PR TITLE
Switch to JaxABM

### DIFF
--- a/climapan_lab/jax_calibrate.py
+++ b/climapan_lab/jax_calibrate.py
@@ -1,0 +1,38 @@
+"""Simple calibration interface using JaxABM's ModelCalibrator."""
+
+from jaxabm.analysis import ModelCalibrator, ModelConfig
+
+from .base_params import economic_params
+from .src.models import EconModel
+
+
+def model_factory(params=None, config: ModelConfig | None = None):
+    params_dict = economic_params.copy()
+    if params:
+        params_dict.update(params)
+    seed = params_dict.get("seed", 0)
+    if config is not None:
+        seed = config.seed
+    return EconModel(parameters=params_dict, seed=seed)
+
+
+def run_calibration():
+    initial_params = {"wageAdjustmentRate": economic_params["wageAdjustmentRate"]}
+    target_metrics = {"UnemploymentRate": 0.05}
+    param_bounds = {"wageAdjustmentRate": (0.0001, 0.01)}
+
+    calibrator = ModelCalibrator(
+        model_factory=model_factory,
+        initial_params=initial_params,
+        target_metrics=target_metrics,
+        param_bounds=param_bounds,
+        evaluation_steps=200,
+        max_iterations=10,
+    )
+
+    best_params = calibrator.calibrate(verbose=True)
+    print("Best parameters:", best_params)
+
+
+if __name__ == "__main__":
+    run_calibration()

--- a/climapan_lab/run_sim.py
+++ b/climapan_lab/run_sim.py
@@ -15,7 +15,7 @@ import warnings
 from datetime import datetime
 from itertools import product
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed

--- a/climapan_lab/src/banks/Bank.py
+++ b/climapan_lab/src/banks/Bank.py
@@ -1,14 +1,20 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 import pandas as pd
 
+from ..param_dict import ParamDict
+
 
 class Bank(ap.Agent):
     """A bank agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         self.loans = 0

--- a/climapan_lab/src/climate/Climate.py
+++ b/climapan_lab/src/climate/Climate.py
@@ -1,10 +1,16 @@
 import copy
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
+
+from ..param_dict import ParamDict
 
 
 class Climate(ap.Agent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
+
     def setup(self):
         self.climate_shock_start = self.p.climate_shock_start
         self.zeta_g = (self.p.climateZetaGreen,)

--- a/climapan_lab/src/consumers/Consumer.py
+++ b/climapan_lab/src/consumers/Consumer.py
@@ -1,15 +1,20 @@
 import copy
 import math
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 
+from ..param_dict import ParamDict
 from ..utils import lognormal
 
 
 class Consumer(ap.Agent):
     """A consumer agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
 
@@ -183,6 +188,18 @@ class Consumer(ap.Agent):
 
     def getConsumerType(self):
         return self.consumerType
+
+    # ------------------------------------------------------------------
+    # Compatibility attributes
+    # ------------------------------------------------------------------
+    @property
+    def type(self):
+        """Alias for ``consumerType`` used in legacy tests."""
+        return self.consumerType
+
+    @type.setter
+    def type(self, value):
+        self.consumerType = value
 
     def getBelongToFirm(self):
         return self.belongToFirm

--- a/climapan_lab/src/firms/BrownEnergyFirm.py
+++ b/climapan_lab/src/firms/BrownEnergyFirm.py
@@ -1,7 +1,7 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 

--- a/climapan_lab/src/firms/CapitalGoodsFirm.py
+++ b/climapan_lab/src/firms/CapitalGoodsFirm.py
@@ -1,17 +1,22 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 from scipy.optimize import minimize
 
+from ..param_dict import ParamDict
 from ..utils import days_in_month
 from .GoodsFirmBase import GoodsFirmBase
 
 
 class CapitalGoodsFirm(GoodsFirmBase):
     """A CapitalGoodsFirm agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         super().setup()
@@ -64,10 +69,9 @@ class CapitalGoodsFirm(GoodsFirmBase):
         """"""
         self.set_aggregate_demand(0)
         self.soldProducts = 0
-        self.consumersList = self.model.aliveConsumers.select(
-            self.model.aliveConsumers.getCovidStateAttr("state") != "dead"
-            and self.model.aliveConsumers.getAgeGroup() == "working"
-        )
+        state_ok = self.model.aliveConsumers.getCovidStateAttr("state") != "dead"
+        working = self.model.aliveConsumers.getAgeGroup() == "working"
+        self.consumersList = self.model.aliveConsumers.select(state_ok & working)
 
     def calculate_input_demand(self):
         """"""

--- a/climapan_lab/src/firms/ConsumerGoodsFirm.py
+++ b/climapan_lab/src/firms/ConsumerGoodsFirm.py
@@ -1,17 +1,22 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 from scipy.optimize import minimize
 
+from ..param_dict import ParamDict
 from ..utils import days_in_month
 from .GoodsFirmBase import GoodsFirmBase
 
 
 class ConsumerGoodsFirm(GoodsFirmBase):
     """A ConsumerGoodsFirm agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         super().setup()
@@ -70,10 +75,9 @@ class ConsumerGoodsFirm(GoodsFirmBase):
         self.market_shareList.append(self.market_share)"""
         self.set_aggregate_demand(0)
         self.soldProducts = 0
-        self.consumersList = self.model.aliveConsumers.select(
-            self.model.aliveConsumers.getCovidStateAttr("state") != "dead"
-            and self.model.aliveConsumers.getAgeGroup() == "working"
-        )
+        state_ok = self.model.aliveConsumers.getCovidStateAttr("state") != "dead"
+        working = self.model.aliveConsumers.getAgeGroup() == "working"
+        self.consumersList = self.model.aliveConsumers.select(state_ok & working)
         # market share
 
     def calculate_input_demand(self):

--- a/climapan_lab/src/firms/EnergyFirmBase.py
+++ b/climapan_lab/src/firms/EnergyFirmBase.py
@@ -1,13 +1,19 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
+
+from ..param_dict import ParamDict
 
 
 class EnergyFirmBase(ap.Agent):
     """A EnergyFirmBase agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         # Main Variables

--- a/climapan_lab/src/firms/GoodsFirmBase.py
+++ b/climapan_lab/src/firms/GoodsFirmBase.py
@@ -1,16 +1,21 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 from scipy.optimize import minimize
 
+from ..param_dict import ParamDict
 from ..utils import days_in_month
 
 
 class GoodsFirmBase(ap.Agent):
     """A GoodsFirmBase agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
 

--- a/climapan_lab/src/firms/GreenEnergyFirm.py
+++ b/climapan_lab/src/firms/GreenEnergyFirm.py
@@ -1,15 +1,20 @@
 import copy
 from collections import OrderedDict
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import numpy.random as random
 
+from ..param_dict import ParamDict
 from .EnergyFirmBase import EnergyFirmBase
 
 
 class GreenEnergyFirm(EnergyFirmBase):
     """A GreenEnergyFirm agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         super().setup()

--- a/climapan_lab/src/governments/Goverment.py
+++ b/climapan_lab/src/governments/Goverment.py
@@ -1,11 +1,18 @@
 # Government
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import pandas as pd
 
 
+from ..param_dict import ParamDict
+
+
 class Government(ap.Agent):
     """A government agent"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.p = ParamDict(self.p)
 
     def setup(self):
         self.taxRate = self.p.taxRate

--- a/climapan_lab/src/legacy.py
+++ b/climapan_lab/src/legacy.py
@@ -1,0 +1,146 @@
+"""Compatibility helpers for migrating from AgentPy to JaxABM."""
+
+import jaxabm.agentpy as ap
+import numpy as np
+from .param_dict import ParamDict
+
+
+class AgentList(ap.AgentList):
+    """AgentList with list-style indexing for backward compatibility.
+
+    The original AgentPy library created Python agent objects during ``setup``
+    so that they could be accessed and modified before the simulation run.  In
+    JaxABM, agent states are initialised lazily when ``Model.initialize`` is
+    called.  This wrapper therefore constructs lightweight agent instances on
+    creation and stores them in ``_agent_cache`` so that tests expecting the
+    AgentPy behaviour continue to work.
+    """
+
+    def __init__(self, model, n, agent_class, **kwargs):
+        params = kwargs or dict(getattr(model, "p", {}))
+        super().__init__(model, n, agent_class, **params)
+        # Ensure underlying agent wrapper uses attribute access
+        if hasattr(self, "agent_type"):
+            self.agent_type.agent_instance.p = ParamDict(dict(params))
+            self.agent_type.agent_instance.model = model
+        self._agent_cache = []
+        for i in range(self.n):
+            a = self.agent_class()
+            a.model = self.model
+            a.id = i
+            base_params = self.params if self.params else getattr(self.model, "p", {})
+            a.p = ParamDict(dict(base_params))
+            a._state = {}
+            self._agent_cache.append(a)
+        # Register with the model for state updates, emulating Model.add_agents
+        if hasattr(self.model, "_agent_lists"):
+            name = getattr(self, "name", None)
+            if not name:
+                name = self.agent_class.__name__.lower() + "s"
+            self.model._agent_lists[name] = self
+            self.name = name
+            self.model._agent_instances[name] = list(self._agent_cache)
+            # Include template agent so that attribute assignments during
+            # initialization update its local state correctly
+            self.model._agent_instances[name].append(self.agent_type.agent_instance)
+
+        # After registration, call setup on each agent so that state-setting
+        # logic can safely use the model's update hooks.
+        for a in self._agent_cache:
+            init_state = a.setup()
+            if isinstance(init_state, dict):
+                a._state.update(init_state)
+
+
+    def _get_state_at(self, index):
+        """Return a dictionary of state values for the agent at ``index``."""
+        # Access states directly from the underlying collection to avoid
+        # triggering property lookups that expect a fully initialized model.
+        states = self.collection.states
+        if not states:
+            return self._agent_cache[index]._state
+        return {k: v[index] for k, v in states.items()}
+
+    def __getitem__(self, index):
+        """Return a temporary agent object at ``index``.
+
+        JaxABM's :class:`AgentCollection` does not support subscripting, so
+        we recreate an :class:`Agent` instance using the stored states.  This
+        mimics the old AgentPy behaviour that tests rely on.
+        """
+        if index >= len(self._agent_cache):
+            raise IndexError("Agent index out of range")
+        agent = self._agent_cache[index]
+        states = self.collection.states
+        if states:
+            agent._state = self._get_state_at(index)
+        return agent
+
+    def __setitem__(self, index, value):
+        """Assign a complete state dictionary to the agent at ``index``."""
+        if not hasattr(value, "_state"):
+            raise ValueError("Value must be an Agent with '_state' attribute")
+        states = self.collection.states
+        if states:
+            for k in states:
+                states[k] = states[k].at[index].set(value._state.get(k, states[k][index]))
+        if index < len(self._agent_cache):
+            self._agent_cache[index] = value
+
+    def __add__(self, other):
+        if isinstance(other, AgentList):
+            return self._agent_cache + other._agent_cache
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, list):
+            return other + self._agent_cache
+        return NotImplemented
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers replicating AgentPy AgentList behaviour
+    # ------------------------------------------------------------------
+    def getCovidStateAttr(self, attr):
+        """Return an array of covid state attributes for all agents."""
+        return np.array([a.getCovidStateAttr(attr) for a in self._agent_cache])
+
+    def isDead(self):
+        """Return boolean array whether each agent is dead."""
+        return np.array([a.isDead() for a in self._agent_cache])
+
+    def isEmployed(self):
+        """Return boolean array whether each agent is employed."""
+        return np.array([a.isEmployed() for a in self._agent_cache])
+
+    def select(self, condition):
+        """Select agents by boolean mask or callable condition."""
+        if callable(condition):
+            return super().select(condition)
+        mask = np.array(condition)
+        filtered_count = int(np.sum(mask))
+        filtered = AgentList(self.model, filtered_count, self.agent_class, **self.params)
+        if hasattr(self.collection, 'states') and self.collection.states is not None:
+            if hasattr(self.collection, 'filter'):
+                filtered.collection = self.collection.filter(lambda s: mask)
+        # keep cache consistent
+        filtered._agent_cache = [a for a, m in zip(self._agent_cache, mask) if m]
+        return filtered
+
+    def __iter__(self):
+        """Iterate over cached agent instances only."""
+        return iter(self._agent_cache)
+
+    def __getattr__(self, name):
+        """Delegate unknown attribute access to underlying agents."""
+        states = getattr(self.collection, 'states', None)
+        if states is not None and name in states:
+            return super().__getattr__(name)
+        if hasattr(self.agent_class, name):
+            def aggregator(*args, **kwargs):
+                return np.array([
+                    getattr(a, name)(*args, **kwargs) for a in self._agent_cache
+                ])
+            return aggregator
+        if self._agent_cache and hasattr(self._agent_cache[0], name):
+            return [getattr(a, name) for a in self._agent_cache]
+        return super().__getattr__(name)

--- a/climapan_lab/src/param_dict.py
+++ b/climapan_lab/src/param_dict.py
@@ -1,0 +1,11 @@
+class ParamDict(dict):
+    """Dictionary supporting attribute-style access."""
+
+    def __getattr__(self, item):
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError(item)
+
+    def __setattr__(self, key, value):
+        self[key] = value

--- a/climapan_lab/validate_sim.py
+++ b/climapan_lab/validate_sim.py
@@ -9,7 +9,7 @@ using autocorrelation analysis and parameter calibration.
 import argparse
 import warnings
 
-import agentpy as ap
+import jaxabm.agentpy as ap
 import numpy as np
 import pandas as pd
 import sobol_seq

--- a/docs/_build/html/_modules/climapan_lab/src/banks/Bank.html
+++ b/docs/_build/html/_modules/climapan_lab/src/banks/Bank.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">pandas</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">pd</span>

--- a/docs/_build/html/_modules/climapan_lab/src/climate/Climate.html
+++ b/docs/_build/html/_modules/climapan_lab/src/climate/Climate.html
@@ -231,7 +231,7 @@
   <h1>Source code for climapan_lab.src.climate.Climate</h1><div class="highlight"><pre>
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 
 

--- a/docs/_build/html/_modules/climapan_lab/src/consumers/Consumer.html
+++ b/docs/_build/html/_modules/climapan_lab/src/consumers/Consumer.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">math</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 

--- a/docs/_build/html/_modules/climapan_lab/src/firms/BrownEnergyFirm.html
+++ b/docs/_build/html/_modules/climapan_lab/src/firms/BrownEnergyFirm.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 

--- a/docs/_build/html/_modules/climapan_lab/src/firms/CapitalGoodsFirm.html
+++ b/docs/_build/html/_modules/climapan_lab/src/firms/CapitalGoodsFirm.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">scipy.optimize</span><span class="w"> </span><span class="kn">import</span> <span class="n">minimize</span>

--- a/docs/_build/html/_modules/climapan_lab/src/firms/ConsumerGoodsFirm.html
+++ b/docs/_build/html/_modules/climapan_lab/src/firms/ConsumerGoodsFirm.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">scipy.optimize</span><span class="w"> </span><span class="kn">import</span> <span class="n">minimize</span>

--- a/docs/_build/html/_modules/climapan_lab/src/firms/GreenEnergyFirm.html
+++ b/docs/_build/html/_modules/climapan_lab/src/firms/GreenEnergyFirm.html
@@ -232,7 +232,7 @@
 <span></span><span class="kn">import</span><span class="w"> </span><span class="nn">copy</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy.random</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">random</span>
 

--- a/docs/_build/html/_modules/climapan_lab/src/governments/Goverment.html
+++ b/docs/_build/html/_modules/climapan_lab/src/governments/Goverment.html
@@ -230,7 +230,7 @@
              
   <h1>Source code for climapan_lab.src.governments.Goverment</h1><div class="highlight"><pre>
 <span></span><span class="c1"># Government</span>
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">pandas</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">pd</span>
 

--- a/docs/_build/html/_modules/climapan_lab/src/models.html
+++ b/docs/_build/html/_modules/climapan_lab/src/models.html
@@ -242,7 +242,7 @@
 <span class="kn">from</span><span class="w"> </span><span class="nn">collections</span><span class="w"> </span><span class="kn">import</span> <span class="n">OrderedDict</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">datetime</span><span class="w"> </span><span class="kn">import</span> <span class="n">date</span><span class="p">,</span> <span class="n">timedelta</span>
 
-<span class="kn">import</span><span class="w"> </span><span class="nn">agentpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">jaxabm</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">ap</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 
 <span class="kn">from</span><span class="w"> </span><span class="nn">.banks.Bank</span><span class="w"> </span><span class="kn">import</span> <span class="n">Bank</span>

--- a/docs/_build/html/_sources/installation.rst.txt
+++ b/docs/_build/html/_sources/installation.rst.txt
@@ -18,7 +18,7 @@ Core Dependencies
 * **numpy** (>=1.21.0) - Numerical computing
 * **pandas** (>=1.3.0) - Data manipulation and analysis
 * **matplotlib** (>=3.5.0) - Plotting and visualization
-* **agentpy** (>=0.1.5) - Agent-based modeling framework
+* **jaxabm** (>=0.1.5) - Agent-based modeling framework
 * **scikit-learn** (>=1.0.0) - Machine learning utilities
 * **scipy** (>=1.7.0) - Scientific computing
 * **joblib** (>=1.1.0) - Parallel computing
@@ -95,7 +95,7 @@ Troubleshooting
 Common Issues
 ~~~~~~~~~~~~~
 
-**Import Error: No module named 'agentpy'**
+**Import Error: No module named 'jaxabm'**
 
 This usually means the dependencies weren't installed properly. Try:
 

--- a/docs/_build/html/installation.html
+++ b/docs/_build/html/installation.html
@@ -249,7 +249,7 @@
 <li><p><strong>numpy</strong> (&gt;=1.21.0) - Numerical computing</p></li>
 <li><p><strong>pandas</strong> (&gt;=1.3.0) - Data manipulation and analysis</p></li>
 <li><p><strong>matplotlib</strong> (&gt;=3.5.0) - Plotting and visualization</p></li>
-<li><p><strong>agentpy</strong> (&gt;=0.1.5) - Agent-based modeling framework</p></li>
+<li><p><strong>jaxabm</strong> (&gt;=0.1.5) - Agent-based modeling framework</p></li>
 <li><p><strong>scikit-learn</strong> (&gt;=1.0.0) - Machine learning utilities</p></li>
 <li><p><strong>scipy</strong> (&gt;=1.7.0) - Scientific computing</p></li>
 <li><p><strong>joblib</strong> (&gt;=1.1.0) - Parallel computing</p></li>
@@ -316,7 +316,7 @@ pip<span class="w"> </span>install<span class="w"> </span>git+https://github.com
 <h2>Troubleshooting<a class="headerlink" href="#troubleshooting" title="Link to this heading"></a></h2>
 <section id="common-issues">
 <h3>Common Issues<a class="headerlink" href="#common-issues" title="Link to this heading"></a></h3>
-<p><strong>Import Error: No module named ‘agentpy’</strong></p>
+<p><strong>Import Error: No module named ‘jaxabm’</strong></p>
 <p>This usually means the dependencies weren’t installed properly. Try:</p>
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>pip<span class="w"> </span>install<span class="w"> </span>-r<span class="w"> </span>requirements.txt
 </pre></div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,4 +135,4 @@ intersphinx_mapping = {
 master_doc = "index"
 
 # Mock imports for dependencies that might not be available during build
-autodoc_mock_imports = ["agentpy", "pathos", "salib", "h5py"]
+autodoc_mock_imports = ["jaxabm", "pathos", "salib", "h5py"]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,7 @@ Core Dependencies
 * **numpy** (>=1.21.0) - Numerical computing
 * **pandas** (>=1.3.0) - Data manipulation and analysis
 * **matplotlib** (>=3.5.0) - Plotting and visualization
-* **agentpy** (>=0.1.5) - Agent-based modeling framework
+* **jaxabm** (>=0.1.0) - Agent-based modeling framework
 * **scikit-learn** (>=1.0.0) - Machine learning utilities
 * **scipy** (>=1.7.0) - Scientific computing
 * **joblib** (>=1.1.0) - Parallel computing
@@ -27,6 +27,8 @@ Core Dependencies
 * **pathos** (>=0.2.8) - Parallel processing
 * **dill** (>=0.3.4) - Serialization
 * **h5py** (>=3.7.0) - HDF5 file handling
+* **statsmodels** (>=0.13.0) - Statistical analysis utilities
+* **plotly** (>=5.0) - Interactive plotting
 
 Installation Methods
 --------------------
@@ -95,7 +97,7 @@ Troubleshooting
 Common Issues
 ~~~~~~~~~~~~~
 
-**Import Error: No module named 'agentpy'**
+**Import Error: No module named 'jaxabm'**
 
 This usually means the dependencies weren't installed properly. Try:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,7 +19,7 @@ interrogate>=1.5.0
 requests>=2.28.0
 
 # Mock these to avoid installation issues on RTD
-# agentpy
+# jaxabm
 # pathos
 # salib
 # dill 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy>=1.21.0",
     "pandas>=1.3.0",
     "matplotlib>=3.5.0",
-    "jaxabm>=0.1.0",
+    "jaxabm @ git+https://github.com/a11to1n3/JaxABM.git",
     "scikit-learn>=1.0.0",
     "scipy>=1.7.0",
     "joblib>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy>=1.21.0",
     "pandas>=1.3.0",
     "matplotlib>=3.5.0",
-    "agentpy>=0.1.5",
+    "jaxabm>=0.1.0",
     "scikit-learn>=1.0.0",
     "scipy>=1.7.0",
     "joblib>=1.1.0",
@@ -39,6 +39,9 @@ dependencies = [
     "pathos>=0.2.8",
     "dill>=0.3.4",
     "h5py>=3.7.0",
+    "psutil>=5.0",
+    "statsmodels>=0.13.0",
+    "plotly>=5.0",
 ]
 
 [project.optional-dependencies]
@@ -95,4 +98,4 @@ profile = "black"
 multi_line_output = 3
 line_length = 88
 known_first_party = ["climapan_lab"]
-known_third_party = ["agentpy", "numpy", "pandas", "matplotlib", "sklearn", "scipy", "joblib", "salib", "networkx", "pathos", "dill", "h5py"] 
+known_third_party = ["jaxabm", "numpy", "pandas", "matplotlib", "sklearn", "scipy", "joblib", "salib", "networkx", "pathos", "dill", "h5py"] 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 numpy>=1.21.0
 pandas>=1.3.0
 matplotlib>=3.5.0
-agentpy>=0.1.5
+jaxabm>=0.1.0
 scikit-learn>=1.0.0
 scipy>=1.7.0
 joblib>=1.1.0
@@ -16,4 +16,5 @@ pathos>=0.2.8
 dill>=0.3.4
 h5py>=3.7.0
 statsmodels>=0.13.0
-plotly>=5.0 
+plotly>=5.0
+psutil>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 numpy>=1.21.0
 pandas>=1.3.0
 matplotlib>=3.5.0
-jaxabm>=0.1.0
+jaxabm @ git+https://github.com/a11to1n3/JaxABM.git
 scikit-learn>=1.0.0
 scipy>=1.7.0
 joblib>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "numpy>=1.21.0",
         "pandas>=1.3.0",
         "matplotlib>=3.5.0",
-        "agentpy>=0.1.5",
+        "jaxabm>=0.1.0",
         "scikit-learn>=1.0.0",
         "scipy>=1.7.0",
         "joblib>=1.1.0",


### PR DESCRIPTION
## Summary
- introduce compatibility AgentList to mimic AgentPy style indexing
- initialise agent objects and register them with the model
- add helper methods for accessing agent status and selection
- track simulation time steps in EconModel and expose results via `output`
- fix pre-simulation agent access and results formatting
- add psutil dependency

## Testing
- `pip install git+https://github.com/a11to1n3/JaxABM.git`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68447217d54c83258e7435fb5642803d